### PR TITLE
Adds import resolver fixing missing file extension

### DIFF
--- a/code/validation/.eslintrc
+++ b/code/validation/.eslintrc
@@ -10,7 +10,12 @@
     "import/ignore": [
       "node_modules",
       ".(scss|less|css|png|jpg|po|svg)$"
-    ]
+    ],
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".ios.js", ".android.js"]
+      }
+    }
   },
   "rules": {
     // not sure why airbnb turned this on. gross!


### PR DESCRIPTION
Fixes issues such as:

> ESLint: Missing file extension for "react-native-linear-gradient" (import/extensions)

