### PR TITLE
update_typescript_static_validation

### DIFF
--- a/code/validation/2021.06/.eslintrc.js
+++ b/code/validation/2021.06/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+    extends: ['airbnb-typescript', 'prettier', 'plugin:prettier/recommended'],
+    rules: {
+        'react/jsx-indent': ['error', 4],
+        'react/jsx-indent-props': ['error', 4],
+        'import/prefer-default-export': 0,
+        'no-param-reassign': 'off',
+        'react/prop-types': 'off',
+        'prefer-destructuring': [
+            'error',
+            {
+                array: true,
+                object: true,
+            },
+            {
+                enforceForRenamedProperties: false,
+            },
+        ],
+    },
+    parserOptions: {
+        project: './tsconfig.json',
+    },
+};

--- a/code/validation/2021.06/.prettierrc.js
+++ b/code/validation/2021.06/.prettierrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+    bracketSpacing: false,
+    trailingComma: 'all',
+    jsxBracketSameLine: false,
+    printWidth: 120,
+    singleQuote: true,
+    tabWidth: 4,
+    arrowParens: 'always',
+    quoteProps: 'consistent',
+};

--- a/code/validation/2021.06/coveragerc
+++ b/code/validation/2021.06/coveragerc
@@ -1,0 +1,31 @@
+[run]
+source = src
+
+omit =
+    *manage.py,
+    *settings/*,
+    *migrations/*,
+    *wsgi.py,
+    *asgi.py
+
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    return NotImplemented
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+[html]
+directory = coverage/python

--- a/code/validation/2021.06/prospector.yml
+++ b/code/validation/2021.06/prospector.yml
@@ -1,0 +1,77 @@
+inherits:
+  - strictness_veryhigh
+
+uses:
+    - django
+    - celery
+
+ignore-patterns:
+  - ^setup.py$
+  - wsgi.py$
+  - ^static
+
+pylint:
+  disable:
+    - missing-final-newline
+    - too-few-public-methods
+    - too-many-ancestors
+    - unsubscriptable-object # this was added due to list[int] support, remove in python 3.10
+    - bad-whitespace
+    - W0613  # allow Unused arguments
+    - W0142  # allow Used * or ** magic
+    - R0201  # disable no-self-use
+
+  options:
+    max-locals: 25
+    max-returns: 6
+    max-branches: 20
+    max-statements: 60
+    min-public-methods: 1
+    max-public-methods: 24
+    max-line-length: 120
+    max-args: 10
+    max-module-lines: 1200
+    max-attributes: 8
+    # Regular expressions used to match various names
+    # (we allow longer names than default)
+    argument-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    attr-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    function-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    method-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    variable-rgx: "[a-z_][a-z0-9_]{2,60}$"
+
+pep8:
+  options:
+    max-line-length: 120
+  disable:
+    - W292  # no newline at end of file
+    - W391  # blank line at end of file
+    - E402
+
+pyroma:
+  disable:
+    - PYR15
+    - PYR18
+    - PYR17
+
+pep257:
+  run: true
+  disable:
+    - D100  # Missing docstring in public module
+    - D101  # Missing docstring in public class
+    - D104  # Missing docstring in public package
+    - D106  # Missing docstring in public nested class
+    - D202  # No blank lines allowed after function docstring
+    - D203  # 1 blank line required before class docstring
+    - D212  # Multi-line docstring summary should start at the first line
+
+
+mccabe:
+  options:
+    max-complexity: 20
+
+dodgy:
+  run: false
+
+pyflakes:
+  run: false

--- a/code/validation/2021.06/tsconfig.json
+++ b/code/validation/2021.06/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "target": "esnext",
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "jsx": "react",
+        "noEmit": false,
+        "strict": true,
+        "declaration": true,
+        "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/models/**/*.ts"],
+    "exclude": ["babel.config.js", "metro.config.js", "jest.config.js"]
+}


### PR DESCRIPTION
`"allowJs": true` kept this rule because QC app shares JS and TS files, and without this every time a JS component is imported in a TS file will prompt an error 