### PR TITLE
add semgrep rules

### DIFF
--- a/code/validation/2022.06/.semgrep_rules.yml
+++ b/code/validation/2022.06/.semgrep_rules.yml
@@ -1,0 +1,148 @@
+rules:
+# Disallow print statements
+- id: python.custom-credit-group.no-prints
+  message: Do not use print statements.
+  languages: [python]
+  severity: INFO
+  pattern: print(...)
+
+# Disallow redefining a loop variable inside the loop
+- id: python.custom-credit-group.no-redefinition-inside-loop
+  message: Do not redefine loop variables inside the loop.
+  languages: [python]
+  severity: WARNING
+  patterns:
+    - pattern-inside: |
+        for $I in $L:
+            ...
+    - pattern: $I = ...
+
+# Disallow making changes to an iterable while iterating it
+- id: python.custom-credit-group.no-iterable-updates-inside-loop
+  message: Do not update/change an iterable while iterating it.
+  languages: [python]
+  severity: ERROR
+  patterns:
+    - pattern-inside: |
+        for $I in $L:
+            ...
+    - pattern: $L[...] = ...
+
+# Disallow usage of the `requests` library
+- id: python.custom-credit-group.no-requests-library
+  message: Do not use the `requests` library. Use `RequestClient` instead.
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern: requests.$METHOD(...)
+
+# Enforce setting `related_name` in Foreign Keys and Many2Many relations
+# TODO: would be awesome to be able to enforce the correct format too!
+- id: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+  message: ForeignKey and ManyToMany relationships must explicitly set the "related_name" property as
+    "<model>_<field>_set".
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      class $M(...):
+        ...
+  - pattern-either:
+      - pattern: $F = django.db.models.ForeignKey(...)
+      - pattern: $F = django.db.models.ManyToManyField(...)
+  - pattern-not: $F = django.db.models.ForeignKey(..., related_name=..., ...)
+  - pattern-not: $F = django.db.models.ManyToManyField(..., related_name=..., ...)
+
+
+# Replaces python.lang.best-practice.unspecified-open-encoding.unspecified-open-encoding to allow variables instead of only strings in the encoding field
+- id: python.custom-credit-group.unspecified-open-encoding
+  message: Missing 'encoding' parameter. 'open()' uses device locale encodings by
+    default, corrupting files with special characters. Specify the encoding to ensure
+    cross-platform support when opening files in text mode (e.g. encoding="utf-8").
+  languages: [python]
+  severity: WARNING
+  patterns:
+  - pattern-inside: open(...)
+  - pattern-not: open(..., encoding=..., ...)
+  - pattern-not: open($F, "...", $B, "...", ...)
+  - pattern-either:
+    - pattern: open($FILE)
+    - patterns:
+      - pattern: open($FILE, ...)
+      - pattern-not: open($FILE, $M, ...)
+      - pattern-not-regex: open\(.*(?:encoding|mode)=.*\)
+    - patterns:
+      - pattern: open($FILE, $MODE, ...)
+      - metavariable-regex:
+          metavariable: $MODE
+          regex: (?!.*b.*)
+    - patterns:
+      - pattern: open($FILE, ..., mode=$MODE, ...)
+      - metavariable-regex:
+          metavariable: $MODE
+          regex: (?!.*b.*)
+  
+# Disallow charfield with choices
+- id: python.custom-credit-group.disallow-charfield-choices
+  message: CharField should not be used with choices. Use IntegerField instead.
+  languages: [python]
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      class $M(...):
+        ...
+  - pattern-either:
+    - pattern: rest_framework.fields.CharField(..., choices=..., ...)
+    - pattern: rest_framework.serializers.CharField(..., choices=..., ...)
+
+# Disallow multiple assignments on one line
+- id: python.custom-credit-group.disallow-multiple-assignments
+  message: Multiple assignments are not allowed
+  languages: [python]
+  severity: WARNING
+  patterns:
+  - pattern: $A = $B = $C
+  - pattern-not-regex: (.+),(.+)=(.+)
+  - metavariable-regex:
+      metavariable: $A
+      regex: ^[A-Za-z0-9_]+$
+  - metavariable-regex:
+      metavariable: $B
+      regex: ^[A-Za-z0-9_]+$
+
+# Disallow use of logging. Use Django REST logger instead.
+- id: python.custom-credit-group.use-django-rest-logger
+  message: Discontinue use of inbuilt logging. Use Django REST Logger instead.
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern: import logging
+
+# Disallow use of cleaned_data.get('field_name') method.
+- id: python.custom-credit-group.disallow-cleaned_data.get
+  message: Access cleaned field explicitly using ['field'].
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: cleaned_data.get(...)
+    - pattern: $PREFIX.cleaned_data.get(...)
+  
+# Disallow src prefix in import path.
+- id: python.custom-credit-group.disallow-src-import-prefix
+  message: Remove .src from import path.
+  languages: [python]
+  severity: ERROR
+  pattern: import src
+
+# Disallow callings model save without setting update_fields.
+- id: python.custom-credit-group.set-update-fields
+  message: Set update fields in model save method. Example object.save(update_fields=['updated_field1', 'updated_field2'])
+  languages: [python]
+  severity: ERROR
+  patterns:
+    - pattern: $MODEL.save(...)
+    - pattern-not: $MODEL.save(..., update_fields=..., ...)

--- a/code/validation/2022.06/coveragerc
+++ b/code/validation/2022.06/coveragerc
@@ -1,0 +1,31 @@
+[run]
+source = src
+
+omit =
+    *manage.py,
+    *settings/*,
+    *migrations/*,
+    *wsgi.py,
+    *asgi.py
+
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    return NotImplemented
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+[html]
+directory = coverage/python

--- a/code/validation/2022.06/eslintrc.js
+++ b/code/validation/2022.06/eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+    extends: ['airbnb-typescript', 'prettier', 'plugin:prettier/recommended'],
+    rules: {
+        'react/jsx-indent': ['error', 4],
+        'react/jsx-indent-props': ['error', 4],
+        'import/prefer-default-export': 0,
+        'no-param-reassign': 0,
+        'react/prop-types': 0,
+        'react/require-default-props': 0,
+        '@typescript-eslint/no-explicit-any': 2,
+        'prefer-destructuring': [
+            'error',
+            {
+                array: false,
+                object: true,
+            },
+            {
+                enforceForRenamedProperties: false,
+            },
+        ],
+    },
+    parserOptions: {
+        project: './tsconfig.json',
+    },
+};

--- a/code/validation/2022.06/prettierrc.js
+++ b/code/validation/2022.06/prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    bracketSpacing: false,
+    trailingComma: 'all',
+    printWidth: 120,
+    singleQuote: true,
+    tabWidth: 4,
+    arrowParens: 'always',
+    quoteProps: 'consistent',
+};

--- a/code/validation/2022.06/prospector.yml
+++ b/code/validation/2022.06/prospector.yml
@@ -1,0 +1,73 @@
+inherits:
+  - strictness_veryhigh
+
+uses:
+    - django
+    - celery
+
+ignore-patterns:
+  - ^setup.py$
+  - wsgi.py$
+  - ^static
+
+pylint:
+  disable:
+    - too-few-public-methods
+    - too-many-ancestors
+    - inherit-non-class
+    - W0613  # allow Unused arguments
+    - W0142  # allow Used * or ** magic
+    - R0201  # disable no-self-use
+
+  options:
+    max-locals: 25
+    max-returns: 6
+    max-branches: 20
+    max-statements: 60
+    min-public-methods: 1
+    max-public-methods: 24
+    max-line-length: 120
+    max-args: 10
+    max-module-lines: 1200
+    max-attributes: 8
+    # Regular expressions used to match various names
+    # (we allow longer names than default)
+    argument-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    attr-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    function-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    method-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    variable-rgx: "[a-z_][a-z0-9_]{2,60}$"
+
+pep8:
+  options:
+    max-line-length: 120
+  disable:
+    - E402
+
+pyroma:
+  disable:
+    - PYR15
+    - PYR18
+    - PYR17
+
+pep257:
+  run: true
+  disable:
+    - D100  # Missing docstring in public module
+    - D101  # Missing docstring in public class
+    - D104  # Missing docstring in public package
+    - D106  # Missing docstring in public nested class
+    - D202  # No blank lines allowed after function docstring
+    - D203  # 1 blank line required before class docstring
+    - D212  # Multi-line docstring summary should start at the first line
+
+
+mccabe:
+  options:
+    max-complexity: 20
+
+dodgy:
+  run: false
+
+pyflakes:
+  run: false

--- a/code/validation/2022.06/tsconfig.json
+++ b/code/validation/2022.06/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "target": "esnext",
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "jsx": "react",
+        "noEmit": false,
+        "strict": true,
+        "declaration": true,
+        "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/models/**/*.ts"],
+    "exclude": ["babel.config.js", "metro.config.js", "jest.config.js"]
+}


### PR DESCRIPTION
New rules:

* Disallow print statements
* Disallow usage of `requests` (because we must use the RequestClient that is in the common lib
* Enforce usage of `related_name` in FKs
* Correct python.lang.best-practice.unspecified-open-encoding.unspecified-open-encoding
* Disallow CharField being used with choices (must be integer)
* One assignment per line (a = b = c not allowed)
* Force Django REST Logger for logging,
* Disallow `.cleaned_data.get('field_name')` . User `.cleaned_data['field_name']`
* Disallow imports with `src` 
* Disable `.save()` without `update_fields` 