### PR TITLE
Add semgrep rule for variables in log messages.

### DIFF
--- a/code/validation/2022.07/rules/python/no-variables-in-log-messages.yml
+++ b/code/validation/2022.07/rules/python/no-variables-in-log-messages.yml
@@ -5,10 +5,14 @@ rules:
       Do not include variables in log messages. All variables should be moved to
       log.$METHOD(..., details={...})
     languages: [python]
-    severity: WARNING
     patterns:
       - pattern-either:
-          - pattern: django_rest_logger.log.$METHOD(f"{...}...{...}...{...}")
-          - pattern: django_rest_logger.log.$METHOD("{...}...{...}...{...}")
-          - pattern: django_rest_logger.log.$METHOD(f"{...}...")
-          - pattern: django_rest_logger.log.$METHOD(f"..{...}")
+          - pattern: django_rest_logger.log.$METHOD(..., $X, ...)
+          - pattern: django_rest_logger.log.$METHOD(..., message=$X, ...)
+          - pattern: django_rest_logger.log.$METHOD(..., msg=$X, ...)
+      - metavariable-pattern:
+          metavariable: $X
+          patterns:
+            - pattern-not: |
+                "..."
+    severity: WARNING

--- a/code/validation/2022.07/semgrep_rules_python.yml
+++ b/code/validation/2022.07/semgrep_rules_python.yml
@@ -129,13 +129,17 @@ rules:
       Do not include variables in log messages. All variables should be moved to
       log.$METHOD(..., details={...})
     languages: [python]
-    severity: WARNING
     patterns:
       - pattern-either:
-          - pattern: django_rest_logger.log.$METHOD(f"{...}...{...}...{...}")
-          - pattern: django_rest_logger.log.$METHOD("{...}...{...}...{...}")
-          - pattern: django_rest_logger.log.$METHOD(f"{...}...")
-          - pattern: django_rest_logger.log.$METHOD(f"..{...}")
+          - pattern: django_rest_logger.log.$METHOD(..., $X, ...)
+          - pattern: django_rest_logger.log.$METHOD(..., message=$X, ...)
+          - pattern: django_rest_logger.log.$METHOD(..., msg=$X, ...)
+      - metavariable-pattern:
+          metavariable: $X
+          patterns:
+            - pattern-not: |
+                "..."
+    severity: WARNING
 # We can not activate these rules yet
 
 # Disallow callings model save without setting update_fields.

--- a/code/validation/2022.07/targets/python/no-variables-in-log-messages.py
+++ b/code/validation/2022.07/targets/python/no-variables-in-log-messages.py
@@ -1,4 +1,23 @@
-# ruleid: python.custom-credit-group.no-variables-in-log-messages
 import uuid
 user_id = uuid.uuid4()
+name = 'Jogn'
+username = ''
+detail = {
+    'username': '',
+    'name': 'Jogn',
+    'user_id': user_id
+}
+
+# ruleid: python.custom-credit-group.no-variables-in-log-messages
 django_rest_logger.log.error(f'Account not found for {user_id}')
+
+# ruleid: python.custom-credit-group.no-variables-in-log-messages
+django_rest_logger.log.error(
+    f'Account not found for {user_id}'
+    f'Maybe you misspelt your name {name}'
+    f'Or your username {username} was missing'
+    f'Or, just check this detail: {detail}'
+)
+
+# ok: python.custom-credit-group.no-variables-in-log-messages
+django_rest_logger.log.error('Account not found for', details={'user_id':str(user_id)})


### PR DESCRIPTION
The added rules are more robust and they capture the peculiarities of the QC's codebase.