### PR TITLE
Update coveragerc to correct format

### DIFF
--- a/code/validation/2023.03/coveragerc
+++ b/code/validation/2023.03/coveragerc
@@ -2,10 +2,10 @@
 source = src
 
 omit =
-    *manage.py,
-    *settings/*,
-    *migrations/*,
-    *wsgi.py,
+    *manage.py
+    *settings/*
+    *migrations/*
+    *wsgi.py
     *asgi.py
 
 


### PR DESCRIPTION
As per the documentation, the `omit` items don't take any commas. It worked with commas on previous versions, but latest versions of `coverage` ignore those lines and coverage appears as less than 100%