### PR TITLE
Update prospector.yml

### DIFF
--- a/code/validation/2023.03/prospector.yml
+++ b/code/validation/2023.03/prospector.yml
@@ -37,6 +37,7 @@ pylint:
     function-rgx: "[a-z_][a-z0-9_]{2,60}$"
     method-rgx: "[a-z_][a-z0-9_]{2,60}$"
     variable-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    module-rgx: "[a-z0-9_]*"
 
 pep8:
   options:

--- a/code/validation/2023.05/coveragerc
+++ b/code/validation/2023.05/coveragerc
@@ -1,0 +1,31 @@
+[run]
+source = src
+
+omit =
+    *manage.py
+    *settings/*
+    *migrations/*
+    *wsgi.py
+    *asgi.py
+
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    return NotImplemented
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+[html]
+directory = coverage/python

--- a/code/validation/2023.05/eslintrc.js
+++ b/code/validation/2023.05/eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+    extends: ['airbnb', 'airbnb-typescript', 'prettier', 'plugin:prettier/recommended'],
+    rules: {
+        'react/jsx-indent': ['error', 4],
+        'react/jsx-indent-props': ['error', 4],
+        'react/function-component-definition': [2, {namedComponents: 'arrow-function'}],
+        'react/jsx-no-useless-fragment': [2, {allowExpressions: true}],
+        'import/prefer-default-export': 0,
+        'no-param-reassign': 0,
+        'react/prop-types': 0,
+        'react/require-default-props': 0,
+        '@typescript-eslint/no-explicit-any': 2,
+        'prefer-destructuring': [
+            'error',
+            {
+                array: false,
+                object: true,
+            },
+            {
+                enforceForRenamedProperties: false,
+            },
+        ],
+        'import/no-cycle': 0,
+    },
+    parserOptions: {
+        project: './tsconfig.json',
+    },
+};

--- a/code/validation/2023.05/prettierrc.js
+++ b/code/validation/2023.05/prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    bracketSpacing: false,
+    trailingComma: 'all',
+    printWidth: 120,
+    singleQuote: true,
+    tabWidth: 4,
+    arrowParens: 'always',
+    quoteProps: 'consistent',
+};

--- a/code/validation/2023.05/prospector.yml
+++ b/code/validation/2023.05/prospector.yml
@@ -1,0 +1,73 @@
+inherits:
+  - strictness_veryhigh
+
+uses:
+    - django
+    - celery
+
+ignore-patterns:
+  - ^setup.py$
+  - wsgi.py$
+  - ^static
+
+pylint:
+  disable:
+    - too-few-public-methods
+    - too-many-ancestors
+    - inherit-non-class
+    - W0613  # allow Unused arguments
+    - W0142  # allow Used * or ** magic
+    - R0201  # disable no-self-use
+
+  options:
+    max-locals: 25
+    max-returns: 6
+    max-branches: 20
+    max-statements: 60
+    min-public-methods: 1
+    max-public-methods: 24
+    max-line-length: 120
+    max-args: 10
+    max-module-lines: 1200
+    max-attributes: 8
+    # Regular expressions used to match various names
+    # (we allow longer names than default)
+    argument-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    attr-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    function-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    method-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    variable-rgx: "[a-z_][a-z0-9_]{2,60}$"
+
+pep8:
+  options:
+    max-line-length: 120
+  disable:
+    - E402
+
+pyroma:
+  disable:
+    - PYR15
+    - PYR18
+    - PYR17
+
+pep257:
+  run: true
+  disable:
+    - D100  # Missing docstring in public module
+    - D101  # Missing docstring in public class
+    - D104  # Missing docstring in public package
+    - D106  # Missing docstring in public nested class
+    - D202  # No blank lines allowed after function docstring
+    - D203  # 1 blank line required before class docstring
+    - D212  # Multi-line docstring summary should start at the first line
+
+
+mccabe:
+  options:
+    max-complexity: 20
+
+dodgy:
+  run: false
+
+pyflakes:
+  run: false

--- a/code/validation/2023.05/rules/python/disallow-charfield-choices.yml
+++ b/code/validation/2023.05/rules/python/disallow-charfield-choices.yml
@@ -1,0 +1,13 @@
+rules:
+# Disallow charfield with choices
+- id: python.custom-credit-group.disallow-charfield-choices
+  message: CharField should not be used with choices. Use IntegerField instead.
+  languages: [python]
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      class $M(...):
+        ...
+  - pattern-either:
+    - pattern: rest_framework.fields.CharField(..., choices=..., ...)
+    - pattern: rest_framework.serializers.CharField(..., choices=..., ...)

--- a/code/validation/2023.05/rules/python/disallow-cleaned_data.get.yml
+++ b/code/validation/2023.05/rules/python/disallow-cleaned_data.get.yml
@@ -1,0 +1,13 @@
+rules:
+# Disallow use of cleaned_data.get('field_name') method.
+- id: python.custom-credit-group.disallow-cleaned_data.get
+  message: Access cleaned field explicitly using ['field'].
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: cleaned_data.get(...)
+    - pattern: $PREFIX.cleaned_data.get(...)

--- a/code/validation/2023.05/rules/python/disallow-multiple-assignments.yml
+++ b/code/validation/2023.05/rules/python/disallow-multiple-assignments.yml
@@ -1,0 +1,15 @@
+rules:
+# Disallow multiple assignments on one line
+- id: python.custom-credit-group.disallow-multiple-assignments
+  message: Multiple assignments are not allowed
+  languages: [python]
+  severity: WARNING
+  patterns:
+  - pattern: $A = $B = $C
+  - pattern-not-regex: (.+),(.+)=(.+)
+  - metavariable-regex:
+      metavariable: $A
+      regex: ^[A-Za-z0-9_]+$
+  - metavariable-regex:
+      metavariable: $B
+      regex: ^[A-Za-z0-9_]+$

--- a/code/validation/2023.05/rules/python/disallow-src-import-prefix.yml
+++ b/code/validation/2023.05/rules/python/disallow-src-import-prefix.yml
@@ -1,0 +1,7 @@
+rules:
+# Disallow src prefix in import path.
+- id: python.custom-credit-group.disallow-src-import-prefix
+  message: Remove .src from import path.
+  languages: [python]
+  severity: ERROR
+  pattern: import src

--- a/code/validation/2023.05/rules/python/foreign-key-and-many2many-must-set-related-name.yml
+++ b/code/validation/2023.05/rules/python/foreign-key-and-many2many-must-set-related-name.yml
@@ -1,0 +1,17 @@
+rules:
+# Enforce setting `related_name` in Foreign Keys and Many2Many relations
+# TODO: would be awesome to be able to enforce the correct format too!
+- id: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+  message: ForeignKey and ManyToMany relationships must explicitly set the "related_name" property as
+    "<model>_<field>_set".
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      class $M(...):
+        ...
+  - pattern-either:
+      - pattern: $F = django.db.models.ForeignKey(...)
+      - pattern: $F = django.db.models.ManyToManyField(...)
+  - pattern-not: $F = django.db.models.ForeignKey(..., related_name=..., ...)
+  - pattern-not: $F = django.db.models.ManyToManyField(..., related_name=..., ...)

--- a/code/validation/2023.05/rules/python/no-iterable-updates-inside-loop.yml
+++ b/code/validation/2023.05/rules/python/no-iterable-updates-inside-loop.yml
@@ -1,0 +1,11 @@
+rules:
+# Disallow making changes to an iterable while iterating it
+- id: python.custom-credit-group.no-iterable-updates-inside-loop
+  message: Do not update/change an iterable while iterating it.
+  languages: [python]
+  severity: ERROR
+  patterns:
+    - pattern-inside: |
+        for $I in $L:
+            ...
+    - pattern: $L[...] = ...

--- a/code/validation/2023.05/rules/python/no-prints.yml
+++ b/code/validation/2023.05/rules/python/no-prints.yml
@@ -1,0 +1,7 @@
+rules:
+# Disallow print statements
+- id: python.custom-credit-group.no-prints
+  message: Do not use print statements.
+  languages: [python]
+  severity: INFO
+  pattern: print(...)

--- a/code/validation/2023.05/rules/python/no-redefinition-inside-loop.yml
+++ b/code/validation/2023.05/rules/python/no-redefinition-inside-loop.yml
@@ -1,0 +1,11 @@
+rules:
+# Disallow redefining a loop variable inside the loop
+- id: python.custom-credit-group.no-redefinition-inside-loop
+  message: Do not redefine loop variables inside the loop.
+  languages: [python]
+  severity: WARNING
+  patterns:
+    - pattern-inside: |
+        for $I in $L:
+            ...
+    - pattern: $I = ...

--- a/code/validation/2023.05/rules/python/no-requests-library.yml
+++ b/code/validation/2023.05/rules/python/no-requests-library.yml
@@ -1,0 +1,8 @@
+rules:
+# Disallow usage of the `requests` library
+- id: python.custom-credit-group.no-requests-library
+  message: Do not use the `requests` library. Use `RequestClient` instead.
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern: requests.$METHOD(...)

--- a/code/validation/2023.05/rules/python/no-variables-in-log-messages.yml
+++ b/code/validation/2023.05/rules/python/no-variables-in-log-messages.yml
@@ -1,0 +1,18 @@
+rules:
+  # Disallow use of variables in log messages. Use Django REST logger details instead.
+  - id: python.custom-credit-group.no-variables-in-log-messages
+    message:
+      Do not include variables in log messages. All variables should be moved to
+      log.$METHOD(..., details={...})
+    languages: [python]
+    patterns:
+      - pattern-either:
+          - pattern: django_rest_logger.log.$METHOD(..., $X, ...)
+          - pattern: django_rest_logger.log.$METHOD(..., message=$X, ...)
+          - pattern: django_rest_logger.log.$METHOD(..., msg=$X, ...)
+      - metavariable-pattern:
+          metavariable: $X
+          patterns:
+            - pattern-not: |
+                "..."
+    severity: WARNING

--- a/code/validation/2023.05/rules/python/set-update-fields.yml
+++ b/code/validation/2023.05/rules/python/set-update-fields.yml
@@ -1,0 +1,9 @@
+rules:
+# Disallow callings model save without setting update_fields.
+- id: python.custom-credit-group.set-update-fields
+  message: Set update fields in model save method. Example object.save(update_fields=['updated_field1', 'updated_field2'])
+  languages: [python]
+  severity: ERROR
+  patterns:
+    - pattern: $MODEL.save(...)
+    - pattern-not: $MODEL.save(..., update_fields=..., ...)

--- a/code/validation/2023.05/rules/python/unspecified-open-encoding.yml
+++ b/code/validation/2023.05/rules/python/unspecified-open-encoding.yml
@@ -1,0 +1,28 @@
+rules:
+# Replaces python.lang.best-practice.unspecified-open-encoding.unspecified-open-encoding to allow variables instead of only strings in the encoding field
+- id: python.custom-credit-group.unspecified-open-encoding
+  message: Missing 'encoding' parameter. 'open()' uses device locale encodings by
+    default, corrupting files with special characters. Specify the encoding to ensure
+    cross-platform support when opening files in text mode (e.g. encoding="utf-8").
+  languages: [python]
+  severity: WARNING
+  patterns:
+  - pattern-inside: open(...)
+  - pattern-not: open(..., encoding=..., ...)
+  - pattern-not: open($F, "...", $B, "...", ...)
+  - pattern-either:
+    - pattern: open($FILE)
+    - patterns:
+      - pattern: open($FILE, ...)
+      - pattern-not: open($FILE, $M, ...)
+      - pattern-not-regex: open\(.*(?:encoding|mode)=.*\)
+    - patterns:
+      - pattern: open($FILE, $MODE, ...)
+      - metavariable-regex:
+          metavariable: $MODE
+          regex: (?!.*b.*)
+    - patterns:
+      - pattern: open($FILE, ..., mode=$MODE, ...)
+      - metavariable-regex:
+          metavariable: $MODE
+          regex: (?!.*b.*)

--- a/code/validation/2023.05/rules/python/use-django-rest-logger.yml
+++ b/code/validation/2023.05/rules/python/use-django-rest-logger.yml
@@ -1,0 +1,8 @@
+rules:
+# Disallow use of logging. Use Django REST logger instead.
+- id: python.custom-credit-group.use-django-rest-logger
+  message: Discontinue use of inbuilt logging. Use Django REST Logger instead.
+  languages: [python]
+  severity: ERROR
+  patterns:
+  - pattern: import logging

--- a/code/validation/2023.05/rules/python/use-render-with-logging.yml
+++ b/code/validation/2023.05/rules/python/use-render-with-logging.yml
@@ -1,0 +1,10 @@
+rules:
+# Disallow Django's render shortcut because it does not allow logging
+- id: python.custom-credit-group.do-not-use-render-because-does-not-allow-logging
+  languages:
+    - python
+  message:
+    Do not user the render shortcut since it does not allow logging. You should use our
+    internal util render_with_logging
+  pattern: django.shortcuts.render(...)
+  severity: ERROR

--- a/code/validation/2023.05/semgrep_rules_python.yml
+++ b/code/validation/2023.05/semgrep_rules_python.yml
@@ -1,0 +1,205 @@
+rules:
+  # Disallow print statements
+  - id: python.custom-credit-group.no-prints
+    message: Do not use print statements in general code. It's only allowed in Django commands
+    languages: [python]
+    severity: INFO
+    patterns:
+      - pattern-not-inside: |
+          class $M(BaseCommand):
+            ...
+      - pattern: print(...)
+
+  # Disallow redefining a loop variable inside the loop
+  - id: python.custom-credit-group.no-redefinition-inside-loop
+    message: Do not redefine loop variables inside the loop.
+    languages: [python]
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          for $I in $L:
+              ...
+      - pattern: $I = ...
+
+  # Disallow making changes to an iterable while iterating it
+  - id: python.custom-credit-group.no-iterable-updates-inside-loop
+    message: Do not update/change an iterable while iterating it.
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern-inside: |
+          for $I in $L:
+              ...
+      - pattern: $L[...] = ...
+
+  # Disallow usage of the `requests` library
+  - id: python.custom-credit-group.no-requests-library
+    message: Do not use the `requests` library. Use `RequestClient` instead.
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern: requests.$METHOD(...)
+
+  # Replaces python.lang.best-practice.unspecified-open-encoding.unspecified-open-encoding to allow variables instead of only strings in the encoding field
+  - id: python.custom-credit-group.unspecified-open-encoding
+    message:
+      Missing 'encoding' parameter. 'open()' uses device locale encodings by
+      default, corrupting files with special characters. Specify the encoding to ensure
+      cross-platform support when opening files in text mode (e.g. encoding="utf-8").
+    languages: [python]
+    severity: WARNING
+    patterns:
+      - pattern-inside: open(...)
+      - pattern-not: open(..., encoding=..., ...)
+      - pattern-not: open($F, "...", $B, "...", ...)
+      - pattern-either:
+          - pattern: open($FILE)
+          - patterns:
+              - pattern: open($FILE, ...)
+              - pattern-not: open($FILE, $M, ...)
+              - pattern-not-regex: open\(.*(?:encoding|mode)=.*\)
+          - patterns:
+              - pattern: open($FILE, $MODE, ...)
+              - metavariable-regex:
+                  metavariable: $MODE
+                  regex: (?!.*b.*)
+          - patterns:
+              - pattern: open($FILE, ..., mode=$MODE, ...)
+              - metavariable-regex:
+                  metavariable: $MODE
+                  regex: (?!.*b.*)
+
+  # Disallow charfield with choices
+  - id: python.custom-credit-group.disallow-charfield-choices
+    message: CharField should not be used with choices. Use IntegerField instead.
+    languages: [python]
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          class $M(...):
+            ...
+      - pattern-either:
+          - pattern: rest_framework.fields.CharField(..., choices=..., ...)
+          - pattern: rest_framework.serializers.CharField(..., choices=..., ...)
+
+  # Disallow use of logging. Use Django REST logger instead.
+  - id: python.custom-credit-group.use-django-rest-logger
+    message: Discontinue use of inbuilt logging. Use Django REST Logger instead.
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern: import logging
+
+  # Disallow src prefix in import path.
+  - id: python.custom-credit-group.disallow-src-import-prefix
+    message: Remove .src from import path.
+    languages: [python]
+    severity: ERROR
+    pattern: import src
+
+  # Disallow exc_info=True in log.error
+  - id: python.custom-credit-group.no-exc_info-in-log-error
+    message: Dot not use exc_info in log.error, use log.exception
+    languages: [python]
+    severity: WARNING
+    pattern: django_rest_logger.log.error(...,exc_info=True,...)
+
+    # Disallow exc_info in log.exception, default is True and should be kept
+  - id: python.custom-credit-group.no-exc_info-in-log-exception
+    message: Do not change the value of exc_info in log.exception
+    languages: [python]
+    severity: WARNING
+    pattern: django_rest_logger.log.exception(...,exc_info=...,...)
+
+  # Disallow log.error in exception block
+  - id: python.custom-credit-group.reject-log-error-in-except
+    message: Dot not use log.error in exception block, use log.exception
+    languages: [python]
+    severity: WARNING
+    pattern: |
+      try:
+        ...
+      except ...:
+        ...
+        django_rest_logger.log.error(...)
+        ...
+  # Disallow use of variables in log messages. Use Django REST logger details instead.
+    - id: python.custom-credit-group.no-variables-in-log-messages
+    languages:
+    - python
+    message: Do not include variables in log messages. All variables should be moved
+      to log.$METHOD(..., details={...})
+    patterns:
+    - pattern: log.$METHOD(..., details=...)
+    - pattern-not: log.$METHOD(message=..., details=...)
+    - pattern-not: log.$METHOD(msg=..., details=...)
+
+  # Disallow Django's render shortcut because it does not allow logging
+  - id: python.custom-credit-group.do-not-use-render-because-does-not-allow-logging
+    languages:
+      - python
+    message:
+      Do not user the render shortcut since it does not allow logging. You should use our
+      internal util render_with_logging
+    pattern: django.shortcuts.render(...)
+    severity: ERROR
+
+# We can not activate these rules yet
+
+# Disallow callings model save without setting update_fields.
+#- id: python.custom-credit-group.set-update-fields
+#  message: Set update fields in model save method. Example object.save(update_fields=['updated_field1', 'updated_field2'])
+#  languages: [python]
+#  severity: ERROR
+#  patterns:
+#    - pattern: $MODEL.save(...)
+#    - pattern-not: $MODEL.save(..., update_fields=..., ...)
+
+# Disallow use of cleaned_data.get('field_name') method.
+# WHATS NEEDED TO ENABLE: we need to confirm that fields are always available in forms and change QC code
+# - id: python.custom-credit-group.disallow-cleaned_data.get
+#  message: Access cleaned field explicitly using ['field'].
+#  languages: [python]
+#  severity: ERROR
+#  patterns:
+#    - pattern-inside: |
+#        def $FUNC(...):
+#          ...
+#    - pattern-either:
+#        - pattern: cleaned_data.get(...)
+#        - pattern: $PREFIX.cleaned_data.get(...)
+
+# Disallow multiple assignments on one line
+# WHATS NEEDED TO ENABLE: we need to ignore when using update_or_create / get_or_create
+#- id: python.custom-credit-group.disallow-multiple-assignments
+#  message: Multiple assignments are not allowed
+#  languages: [python]
+#  severity: WARNING
+#  patterns:
+#  - pattern: $A = $B = $C
+#  - pattern-not-regex: (.+),(.+)=(.+)
+#  - metavariable-regex:
+#      metavariable: $A
+#      regex: ^[A-Za-z0-9_]+$
+#  - metavariable-regex:
+#      metavariable: $B
+#      regex: ^[A-Za-z0-9_]+$
+
+# Enforce setting `related_name` in Foreign Keys and Many2Many relations
+# WHATS NEEDED TO ENABLE: lots of changes and tests to be done to ensure all code works
+# TODO: would be awesome to be able to enforce the correct format too!
+#- id: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+#  message: ForeignKey and ManyToMany relationships must explicitly set the "related_name" property as
+#    "<model>_<field>_set".
+#  languages: [python]
+#  severity: ERROR
+#  patterns:
+#  - pattern-inside: |
+#      class $M(...):
+#        ...
+#  - pattern-either:
+#      - pattern: $F = django.db.models.ForeignKey(...)
+#      - pattern: $F = django.db.models.ManyToManyField(...)
+#  - pattern-not: $F = django.db.models.ForeignKey(..., related_name=..., ...)
+#  - pattern-not: $F = django.db.models.ManyToManyField(..., related_name=..., ...)
+

--- a/code/validation/2023.05/semgrep_rules_typescript.yml
+++ b/code/validation/2023.05/semgrep_rules_typescript.yml
@@ -1,0 +1,7 @@
+rules:
+  # Disallow console.log statements
+  - id: typescript.custom-credit-group.no-console-log
+    message: Do not use console.log statements in general code
+    languages: [typescript]
+    severity: INFO
+    pattern: console.log(...)

--- a/code/validation/2023.05/targets/python/disallow-charfield-choices.py
+++ b/code/validation/2023.05/targets/python/disallow-charfield-choices.py
@@ -1,0 +1,9 @@
+class TestModel(Model):
+    # ruleid: python.custom-credit-group.disallow-charfield-choices
+    invalid_1 = rest_framework.fields.CharField(choices=['a', 'b'])
+
+    # ruleid: python.custom-credit-group.disallow-charfield-choices
+    invalid_2 = rest_framework.serializers.CharField(choices=['a', 'b'])
+
+    # ok: python.custom-credit-group.disallow-charfield-choices
+    valid = rest_framework.serializers.IntegerField(choices=['a', 'b'])

--- a/code/validation/2023.05/targets/python/disallow-cleaned_data.get.py
+++ b/code/validation/2023.05/targets/python/disallow-cleaned_data.get.py
@@ -1,0 +1,21 @@
+def foo():
+    # ruleid: python.custom-credit-group.disallow-cleaned_data.get
+    value = cleaned_data.get('id')
+
+    # ruleid: python.custom-credit-group.disallow-cleaned_data.get
+    value = self.cleaned_data.get('id')
+
+    # ok: python.custom-credit-group.disallow-cleaned_data.get
+    value = cleaned_data['id']
+
+
+class FooForm(forms.Form):
+    def foo(self):
+        # todoruleid: python.custom-credit-group.disallow-cleaned_data.get
+        value = cleaned_data.get('id')
+
+        # todoruleid: python.custom-credit-group.disallow-cleaned_data.get
+        value = self.cleaned_data.get('id')
+
+        # todook: python.custom-credit-group.disallow-cleaned_data.get
+        value = cleaned_data['id']

--- a/code/validation/2023.05/targets/python/disallow-multiple-assignments.py
+++ b/code/validation/2023.05/targets/python/disallow-multiple-assignments.py
@@ -1,0 +1,9 @@
+
+# ruleid: python.custom-credit-group.disallow-multiple-assignments
+a = b = c
+
+# ok: python.custom-credit-group.disallow-multiple-assignments
+a = b
+
+# ok: python.custom-credit-group.disallow-multiple-assignments
+b = c

--- a/code/validation/2023.05/targets/python/disallow-src-import-prefix.py
+++ b/code/validation/2023.05/targets/python/disallow-src-import-prefix.py
@@ -1,0 +1,11 @@
+# ruleid: python.custom-credit-group.disallow-src-import-prefix
+import src
+
+# ruleid: python.custom-credit-group.disallow-src-import-prefix
+import src.foo.bar
+
+# todoruleid: python.custom-credit-group.disallow-src-import-prefix
+from src.foo.bar import foobar
+
+# todoruleid: python.custom-credit-group.disallow-src-import-prefix
+from src.foo.bar import foobar

--- a/code/validation/2023.05/targets/python/foreign-key-and-many2many-must-set-related-name.py
+++ b/code/validation/2023.05/targets/python/foreign-key-and-many2many-must-set-related-name.py
@@ -1,0 +1,14 @@
+from django.db.models import ForeignKey, ManyToManyField
+_relationship_set : str = 'bar_valid_set'
+class FooModel(Model):
+    # ruleid: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+    invalid_1 = ForeignKey(_relationship_set)
+
+    # ruleid: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+    invalid_2 = ManyToManyField(_relationship_set)
+
+    # ok: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+    valid_1 = ForeignKey(_relationship_set, related_name=_relationship_set)
+
+    # ok: python.custom-credit-group.foreign-key-and-many2many-must-set-related-name
+    valid_2 = ManyToManyField(_relationship_set, related_name=_relationship_set)

--- a/code/validation/2023.05/targets/python/no-iterable-updates-inside-loop.py
+++ b/code/validation/2023.05/targets/python/no-iterable-updates-inside-loop.py
@@ -1,0 +1,30 @@
+
+for value in list_values:
+    new_list_values = []
+
+    # ruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values[0] = 'new_item'
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values = new_list_values
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.append('new_item')
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.insert(-1, 'new_item')
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.extend(new_list_values)
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.remove('existing_item')
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.pop(-1)
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.sort()
+
+    # todoruleid: python.custom-credit-group.no-iterable-updates-inside-loop
+    list_values.reverse()

--- a/code/validation/2023.05/targets/python/no-prints.py
+++ b/code/validation/2023.05/targets/python/no-prints.py
@@ -1,0 +1,2 @@
+# ruleid: python.custom-credit-group.no-prints
+print('')

--- a/code/validation/2023.05/targets/python/no-redefinition-inside-loop.py
+++ b/code/validation/2023.05/targets/python/no-redefinition-inside-loop.py
@@ -1,0 +1,3 @@
+for item in list_items:
+    # ruleid: python.custom-credit-group.no-redefinition-inside-loop
+    item = 0

--- a/code/validation/2023.05/targets/python/no-requests-library.py
+++ b/code/validation/2023.05/targets/python/no-requests-library.py
@@ -1,0 +1,4 @@
+import requests
+
+# ruleid: python.custom-credit-group.no-requests-library
+requests.get('http://placekitten.com/200/300')

--- a/code/validation/2023.05/targets/python/no-variables-in-log-messages.py
+++ b/code/validation/2023.05/targets/python/no-variables-in-log-messages.py
@@ -1,0 +1,23 @@
+import uuid
+user_id = uuid.uuid4()
+name = 'Jogn'
+username = ''
+detail = {
+    'username': '',
+    'name': 'Jogn',
+    'user_id': user_id
+}
+
+# ruleid: python.custom-credit-group.no-variables-in-log-messages
+django_rest_logger.log.error(f'Account not found for {user_id}')
+
+# ruleid: python.custom-credit-group.no-variables-in-log-messages
+django_rest_logger.log.error(
+    f'Account not found for {user_id}'
+    f'Maybe you misspelt your name {name}'
+    f'Or your username {username} was missing'
+    f'Or, just check this detail: {detail}'
+)
+
+# ok: python.custom-credit-group.no-variables-in-log-messages
+django_rest_logger.log.error('Account not found for', details={'user_id':str(user_id)})

--- a/code/validation/2023.05/targets/python/set-update-fields.py
+++ b/code/validation/2023.05/targets/python/set-update-fields.py
@@ -1,0 +1,5 @@
+# ruleid: python.custom-credit-group.set-update-fields
+instance_model.save()
+
+# ok: python.custom-credit-group.set-update-fields
+instance_model.save(update_fields=['updated_field1', 'updated_field2'])

--- a/code/validation/2023.05/targets/python/unspecified-open-encoding.py
+++ b/code/validation/2023.05/targets/python/unspecified-open-encoding.py
@@ -1,0 +1,8 @@
+# ruleid: python.custom-credit-group.unspecified-open-encoding
+open('file.txt')
+
+# ok: python.custom-credit-group.unspecified-open-encoding
+open('file.txt', encoding='utf8')
+
+# ok: python.custom-credit-group.unspecified-open-encoding
+open('file.txt', encoding='utf8', mode='r')

--- a/code/validation/2023.05/targets/python/use-django-rest-logger.py
+++ b/code/validation/2023.05/targets/python/use-django-rest-logger.py
@@ -1,0 +1,2 @@
+# ruleid: python.custom-credit-group.use-django-rest-logger
+import logging

--- a/code/validation/2023.05/targets/python/use-render-with-logging.py
+++ b/code/validation/2023.05/targets/python/use-render-with-logging.py
@@ -1,0 +1,3 @@
+# ruleid: python.custom-credit-group.use-render-with-logging
+from django.shortcuts import render
+render('request', 'template')

--- a/code/validation/2023.05/tsconfig.json
+++ b/code/validation/2023.05/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "target": "esnext",
+        "module": "commonjs",
+        "lib": ["es2019", "dom"],
+        "jsx": "react-native",
+        "noEmit": false,
+        "strict": true,
+        "declaration": true,
+        "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "useUnknownInCatchVariables": false
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/models/**/*.ts"]
+}


### PR DESCRIPTION
Allow module names to contain number, alphabets and _ ...  latest pylint will complain because of django migrate naming convention.