### PR TITLE
Update prospector.yml

### DIFF
--- a/code/validation/2023.03/prospector.yml
+++ b/code/validation/2023.03/prospector.yml
@@ -38,6 +38,7 @@ pylint:
     function-rgx: "[a-z_][a-z0-9_]{2,60}$"
     method-rgx: "[a-z_][a-z0-9_]{2,60}$"
     variable-rgx: "[a-z_][a-z0-9_]{2,60}$"
+    module-rgx: "[a-z0-9_]*"
 
 pep8:
   options:


### PR DESCRIPTION
Latest Python throw this lint error ```Module name "0007_add_dwhcommunicationlogs_model" doesn't conform to snake_case naming style``` This is a django migration naming convention, this patch allows module names to contain numbers, alphabets and underscore